### PR TITLE
Fix typo: Adafruit_SSD1305 -> Adafruit_SSD1327

### DIFF
--- a/examples/ssd1327_test/ssd1327_test.ino
+++ b/examples/ssd1327_test/ssd1327_test.ino
@@ -12,7 +12,7 @@
 #define OLED_RESET -1
 
 // software SPI
-//Adafruit_SSD1305 display(128, 64, OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
+//Adafruit_SSD1327 display(128, 128, OLED_MOSI, OLED_CLK, OLED_DC, OLED_RESET, OLED_CS);
 // hardware SPI
 //Adafruit_SSD1327 display(128, 128, &SPI, OLED_DC, OLED_RESET, OLED_CS);
 


### PR DESCRIPTION
Fix a typo in a commented out SPI example: Adafruit_SSD1305 -> Adafruit_SSD1327.

Also, there are few more references to `SD1305` in the header file, e.g. `SSD1305_SETBRIGHTNESS`.

Tested with the screen.