### PR TITLE
Prevent 'redefinition of class' error during compile

### DIFF
--- a/Adafruit_SSD1327.h
+++ b/Adafruit_SSD1327.h
@@ -14,6 +14,8 @@ Written by Limor Fried/Ladyada  for Adafruit Industries.
 BSD license, check license.txt for more information
 All text above, and the splash screen must be included in any redistribution
 *********************************************************************/
+#ifndef ADAFRUIT_SSD1327_H
+#define ADAFRUIT_SSD1327_H
 
 #include <Adafruit_GrayOLED.h>
 
@@ -75,3 +77,5 @@ private:
   int8_t page_offset = 0;
   int8_t column_offset = 0;
 };
+
+#endif


### PR DESCRIPTION
Wrap .h with 'define' directive so that it can be included in more than one file per project.

Fix compiler 'multiple/redefinition' error when trying to include the header file in the main code file and then again in a sub-library.

This changes the header (.h) file.   It only allows the header to be included once during
compile to avoid a redefinition of class.   This is a common C++ practice and should be done for most header files.
Most users of this library probably never need to reference the header file in more than one place, but in
my case I am passing a reference to the OLED driver to another class and that class also needs to
include the header file.

Example of compiler error in Arduino IDE when the header is referenced in multiple .cpp files.:
In file included from /Users/mark/Documents/GitHub/CircuitMonkey/myproject/OledSlider.h:4,
                 from /Users/mark/Documents/GitHub/CircuitMonkey/myproject/myCode.ino:3:
/Users/mark/Documents/Arduino/libraries/Adafruit_SSD1327/Adafruit_SSD1327.h:61:7: error: redefinition of 'class Adafruit_SSD1327'


