### PR TITLE
Fix unused variables

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
-    - uses: actions/checkout@v2
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3
       with:
          repository: adafruit/ci-arduino
          path: ci

--- a/Adafruit_SSD1327.cpp
+++ b/Adafruit_SSD1327.cpp
@@ -220,7 +220,7 @@ void Adafruit_SSD1327::display(void) {
   // 32-byte transfer condition below.
   yield();
 
-  uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
+  // uint16_t count = WIDTH * ((HEIGHT + 7) / 8);
   uint8_t *ptr = buffer;
   uint8_t dc_byte = 0x40;
   uint8_t rows = HEIGHT;

--- a/examples/ssd1327_test/ssd1327_test.ino
+++ b/examples/ssd1327_test/ssd1327_test.ino
@@ -233,7 +233,7 @@ void testdrawtriangle(void) {
 }
 
 void testfilltriangle(void) {
-  uint8_t color = SSD1327_WHITE;
+  // uint8_t color = SSD1327_WHITE;
   for (int16_t i=min(display.width(),display.height())/2; i>0; i-=5) {
     display.fillTriangle(display.width()/2, display.height()/2-i,
                      display.width()/2-i, display.height()/2+i,
@@ -250,7 +250,7 @@ void testdrawroundrect(void) {
 }
 
 void testfillroundrect(void) {
-  uint8_t color = SSD1327_WHITE;
+  // uint8_t color = SSD1327_WHITE;
   for (uint8_t i=0; i<display.height()/3-2; i+=2) {
     display.fillRoundRect(i, i, display.width()-2*i, display.height()-2*i, display.height()/4,  i % 15 + 1);
     display.display();


### PR DESCRIPTION
this fix some of unused variables, however, this is another narrow conversion from int16_t to uint8_t which is a valid warning. Unfortunately, I don't understand ssd1327 enough to actual fix this probably for now. Just submit this anyway, since it does help a little bit.