### PR TITLE
Add a screensaver method

### DIFF
--- a/Adafruit_SSD1327.cpp
+++ b/Adafruit_SSD1327.cpp
@@ -311,3 +311,16 @@ void Adafruit_SSD1327::display(void) {
 void Adafruit_SSD1327::invertDisplay(bool i) {
   oled_command(i ? SSD1327_INVERTDISPLAY : SSD1327_NORMALDISPLAY);
 }
+
+/*!
+    @brief  Enable or disable the screensaver. While the screensaver
+            is enabled, all updating of the display buffer continues, so
+            when the screensaver is disabled, the display shows the
+            then-current state of the buffer.
+    @param  i
+            If true, enable the screensaver (an all-black display). If
+            false, disable it.
+*/
+void Adafruit_SSD1327::screenSaver(bool i) {
+  oled_command(i ? SSD1327_DISPLAYALLOFF : SSD1327_NORMALDISPLAY);
+}

--- a/Adafruit_SSD1327.h
+++ b/Adafruit_SSD1327.h
@@ -72,6 +72,7 @@ public:
   bool begin(uint8_t i2caddr = SSD1327_I2C_ADDRESS, bool reset = true);
   void display();
   void invertDisplay(bool i);
+  void screenSaver(bool i);
 
 private:
   int8_t page_offset = 0;


### PR DESCRIPTION
This PR adds a new method `screenSaver()`, to enable and disable a screensaver
for the SSD1327. When enabled, the display is all black, and does not change. When
disabled, the display returns to normal and displays whatever is in the buffer at the
time it is disabled.

The method declaration was added to Adafruit_SSD1327.h and the definition was
added to Adafruit_SSD1327.cpp. It was implemented just like the `invertDisplay()` 
method, using the `oled_command()` method and two variables already defined in
Adafruit_SSD1327.h.

There are no known limitations.

I have tested the enabling and disabling of the screensaver, and it appears to work
exactly as intended: when enabled, the display goes all black, and when disabled,
the display immediately shows whatever is in the buffer at that instant.


